### PR TITLE
Add review invitation endpoints

### DIFF
--- a/.insomnia/Request/req_2c7b7d708c2f4340aec60545f487b587.yml
+++ b/.insomnia/Request/req_2c7b7d708c2f4340aec60545f487b587.yml
@@ -1,0 +1,26 @@
+_id: req_2c7b7d708c2f4340aec60545f487b587
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1661363145365
+created: 1661288397352
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id
+  }}/delete_review_access?user_id={% prompt 'User ID to be revoked', '', '',
+  'delete_review_access_role_id', false, true %}"
+name: Delete Review Access
+description: Use this endpoint to completely remove a user and the user's
+  changes from the review.
+method: POST
+body: {}
+parameters: []
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355034.0615
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_2c7b7d708c2f4340aec60545f487b587.yml
+++ b/.insomnia/Request/req_2c7b7d708c2f4340aec60545f487b587.yml
@@ -1,7 +1,7 @@
 _id: req_2c7b7d708c2f4340aec60545f487b587
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1661363145365
+modified: 1661543624645
 created: 1661288397352
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id
   }}/delete_review_access?user_id={% prompt 'User ID to be revoked', '', '',

--- a/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
+++ b/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
@@ -1,7 +1,7 @@
 _id: req_591ce65b6fd948d68770be96b6c0346a
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1661543646566
+modified: 1661870574161
 created: 1661284871451
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/invite"
 name: Invite
@@ -26,7 +26,7 @@ description: >
   | 6       | Reviewer     |
 
 
-  * `user_emails`: An array of strings containing the emails of the invitees.
+  * `user_emails`: An array of strings containing the emails of the invitees. Eg: `["user1@example.com", "user2@example.com"]`.
 
   * `user_reason`: Invitation message to be sent to the invitees.
 method: POST

--- a/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
+++ b/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
@@ -1,7 +1,7 @@
 _id: req_591ce65b6fd948d68770be96b6c0346a
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1661363143376
+modified: 1661543646566
 created: 1661284871451
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/invite"
 name: Invite
@@ -26,7 +26,7 @@ description: >
   | 6       | Reviewer     |
 
 
-  * `user_emails`: A list of emails of the invitees.
+  * `user_emails`: An array of strings containing the emails of the invitees.
 
   * `user_reason`: Invitation message to be sent to the invitees.
 method: POST

--- a/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
+++ b/.insomnia/Request/req_591ce65b6fd948d68770be96b6c0346a.yml
@@ -1,0 +1,56 @@
+_id: req_591ce65b6fd948d68770be96b6c0346a
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1661363143376
+created: 1661284871451
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/invite"
+name: Invite
+description: >
+  Use this endpoint to invite other users to a review. It takes the following
+  parameters in the body:
+
+
+  * `role_id`: The id of the role to assign to the invitees. The table below lists the roles that can be assigned to an invitee:
+
+
+  | Role ID | Role Name    |
+
+  |---------|--------------|
+
+  | 2       | Collaborator |
+
+  | 3       | Viewer       |
+
+  | 4       | Translator   |
+
+  | 6       | Reviewer     |
+
+
+  * `user_emails`: A list of emails of the invitees.
+
+  * `user_reason`: Invitation message to be sent to the invitees.
+method: POST
+body:
+  mimeType: application/json
+  text: >-
+    {
+    	"role_id": {% prompt 'Role ID to assign to invitee', '', '', 'role_id', false, true %},
+    	"user_emails": ["{% prompt 'User email to Invite', '', '', 'invite_user_emails', false, true %}"],
+    	"user_reason": "Invitation Reason Text."
+    }
+parameters: []
+headers:
+  - name: Content-Type
+    value: application/json
+    id: pair_3fe71d3f11b84507ba76b88e352ab407
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355034.4922
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_b007eb5e437e4ec08421b3cbe1af4d13.yml
+++ b/.insomnia/Request/req_b007eb5e437e4ec08421b3cbe1af4d13.yml
@@ -1,13 +1,17 @@
 _id: req_b007eb5e437e4ec08421b3cbe1af4d13
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1661363142961
+modified: 1661543718977
 created: 1661285079214
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/revoke?user_id={% prompt
   'User ID to be revoked', '', '', 'revoke_user_id', false, true %}"
 name: Revoke
-description: Use this endpoint to revoke a user from the review. Revoking does
-  NOT remove decisions or any other changes made by this user.
+description: >-
+  Use this endpoint to revoke a user from the review. Revoking does NOT remove
+  decisions or any other changes made by this user.
+
+
+  Note that this endpoint requires the `revoked_roles` feature flag to be enabled.
 method: POST
 body: {}
 parameters: []

--- a/.insomnia/Request/req_b007eb5e437e4ec08421b3cbe1af4d13.yml
+++ b/.insomnia/Request/req_b007eb5e437e4ec08421b3cbe1af4d13.yml
@@ -1,0 +1,25 @@
+_id: req_b007eb5e437e4ec08421b3cbe1af4d13
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1661363142961
+created: 1661285079214
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/revoke?user_id={% prompt
+  'User ID to be revoked', '', '', 'revoke_user_id', false, true %}"
+name: Revoke
+description: Use this endpoint to revoke a user from the review. Revoking does
+  NOT remove decisions or any other changes made by this user.
+method: POST
+body: {}
+parameters: []
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355034.246
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_c3157fa1496545d39f4c61ae7184d6b9.yml
+++ b/.insomnia/Request/req_c3157fa1496545d39f4c61ae7184d6b9.yml
@@ -1,12 +1,16 @@
 _id: req_c3157fa1496545d39f4c61ae7184d6b9
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1661363142535
+modified: 1661543724396
 created: 1661285178725
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/restore?user_id={%
   prompt 'User ID to be revoked', '', '', 'restore_user_id', false, true %}"
 name: Restore
-description: "Use this endpoint to restore access to a revoked user. "
+description: >-
+  Use this endpoint to restore access to a revoked user. 
+
+
+  Note that this endpoint requires the `revoked_roles` feature flag to be enabled.
 method: POST
 body: {}
 parameters: []

--- a/.insomnia/Request/req_c3157fa1496545d39f4c61ae7184d6b9.yml
+++ b/.insomnia/Request/req_c3157fa1496545d39f4c61ae7184d6b9.yml
@@ -1,0 +1,24 @@
+_id: req_c3157fa1496545d39f4c61ae7184d6b9
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1661363142535
+created: 1661285178725
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/restore?user_id={%
+  prompt 'User ID to be revoked', '', '', 'restore_user_id', false, true %}"
+name: Restore
+description: "Use this endpoint to restore access to a revoked user. "
+method: POST
+body: {}
+parameters: []
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355034.123
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global


### PR DESCRIPTION
Adds the following endpoints and their docs:

* `POST /invite`
* `POST /revoke`
* `POST /restore`
* `POST /delete_review_access`
