### PR TITLE
Add docs for dedup, export and copy endpoints

### DIFF
--- a/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
+++ b/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
@@ -1,7 +1,7 @@
 _id: req_3ec849c6037a4378ac2df957792a47f9
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1677771778978
+modified: 1677773786514
 created: 1676676163211
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
   _.article1_id }}"

--- a/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
+++ b/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
@@ -1,7 +1,7 @@
 _id: req_3ec849c6037a4378ac2df957792a47f9
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1676738024439
+modified: 1677771778978
 created: 1676676163211
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
   _.article1_id }}"
@@ -11,6 +11,9 @@ description: >-
 
 
   Specify the article id in the query path to retrieve all the unresolved duplicates belonging to that article's cluster.
+
+
+  Note that this endpoint should be used for articles that have possible duplicates (identified from the response of `GET /articles` and optionally using the dedup results facet). Otherwise, the result will be empty.
 method: GET
 body: {}
 parameters: []

--- a/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
+++ b/.insomnia/Request/req_3ec849c6037a4378ac2df957792a47f9.yml
@@ -1,0 +1,28 @@
+_id: req_3ec849c6037a4378ac2df957792a47f9
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1676738024439
+created: 1676676163211
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
+  _.article1_id }}"
+name: Duplicates
+description: >-
+  Use this endpoint for retrieving the unresolved articles in a cluster.
+
+
+  Specify the article id in the query path to retrieve all the unresolved duplicates belonging to that article's cluster.
+method: GET
+body: {}
+parameters: []
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355037.4453
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
+++ b/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
@@ -1,0 +1,47 @@
+_id: req_62d5f98e2f984cf4b2152bfdd863075d
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1676741836845
+created: 1676679154425
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
+  _.article1_id }}"
+name: Duplicates
+description: >+
+  Use this endpoint to resolve duplicates. Indicate the article to resolve by
+  specifying the article id in the path.
+
+
+  The following parameters are passed in the body:
+
+
+  - `duplicate_action`: An integer value that denotes the decision to apply to the duplicate. Can take the following values:
+  	- 1 = `USER_ACTION_YES` (article is a duplicate)
+  	- 2 = `USER_ACTION_NO` (article is not a duplicate)
+
+  	
+  - `isDeletedArticle`: Deprecated attribute, always set this to `false` or don't specify it at all.
+
+method: PATCH
+body:
+  mimeType: application/json
+  text: |-
+    {
+    	"duplicate_action": 1,
+    	"isDeletedArticle": false
+    }
+parameters: []
+headers:
+  - name: Content-Type
+    value: application/json
+    id: pair_faa631e2d5d74937b56c83facc5c1b18
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355037.0762
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
+++ b/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
@@ -1,7 +1,7 @@
 _id: req_62d5f98e2f984cf4b2152bfdd863075d
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1676741836845
+modified: 1677771687350
 created: 1676679154425
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
   _.article1_id }}"
@@ -15,8 +15,8 @@ description: >+
 
 
   - `duplicate_action`: An integer value that denotes the decision to apply to the duplicate. Can take the following values:
-  	- 1 = `USER_ACTION_YES` (article is a duplicate)
-  	- 2 = `USER_ACTION_NO` (article is not a duplicate)
+  	- 1 = YES (article is a duplicate)
+  	- 2 = NO (article is not a duplicate)
 
   	
   - `isDeletedArticle`: Deprecated attribute, always set this to `false` or don't specify it at all.

--- a/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
+++ b/.insomnia/Request/req_62d5f98e2f984cf4b2152bfdd863075d.yml
@@ -1,7 +1,7 @@
 _id: req_62d5f98e2f984cf4b2152bfdd863075d
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1677771687350
+modified: 1677773793481
 created: 1676679154425
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/{{
   _.article1_id }}"

--- a/.insomnia/Request/req_6b58b0715a0042c78395825bbe21eef2.yml
+++ b/.insomnia/Request/req_6b58b0715a0042c78395825bbe21eef2.yml
@@ -1,7 +1,7 @@
 _id: req_6b58b0715a0042c78395825bbe21eef2
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1676738040403
+modified: 1677773792094
 created: 1676678767426
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/"
 name: Duplicates
@@ -12,10 +12,13 @@ description: >-
   The response indicates whether the job was triggered, and if it wasn't gives the reason as to why.
 
 
+  Additionally, a push notification will be sent to the frontend application once the dedup job is complete. Dedup results data can then be retrieved using the `GET /articles` or `GET /facets` endpoint.
+
+
   The following are the list of reasons:
 
 
-  - `LIMIT_EXCEEDED`: The review contains more articles than the limit for free reviews.
+  - `LIMIT_EXCEEDED`: The review contains more than the 200,000 article limit for reviews. Contact support to run a dedup job on such a review.
 
   - `JOB_RUNNING`: A dedup job is already running for this review.
 

--- a/.insomnia/Request/req_6b58b0715a0042c78395825bbe21eef2.yml
+++ b/.insomnia/Request/req_6b58b0715a0042c78395825bbe21eef2.yml
@@ -1,0 +1,37 @@
+_id: req_6b58b0715a0042c78395825bbe21eef2
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1676738040403
+created: 1676678767426
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/duplicates/"
+name: Duplicates
+description: >-
+  Use this endpoint to trigger a dedup job for a review.
+
+
+  The response indicates whether the job was triggered, and if it wasn't gives the reason as to why.
+
+
+  The following are the list of reasons:
+
+
+  - `LIMIT_EXCEEDED`: The review contains more articles than the limit for free reviews.
+
+  - `JOB_RUNNING`: A dedup job is already running for this review.
+
+  - `SEARCH_REQUIRED`: A search needs to be added or deleted for a dedup job to be triggered.
+method: POST
+body: {}
+parameters: []
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355037.1992
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_b0483d6f0ea34b7eba74698e529ae1d1.yml
+++ b/.insomnia/Request/req_b0483d6f0ea34b7eba74698e529ae1d1.yml
@@ -1,7 +1,7 @@
 _id: req_b0483d6f0ea34b7eba74698e529ae1d1
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1676745409437
+modified: 1677773613598
 created: 1676743495518
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/copy"
 name: Copy
@@ -15,79 +15,7 @@ description: >-
   - `target_review`: (review id to copy to)
 
 
-  Filters are passed in through the request body and are described below:
-
-
-  - `start`: Number of initial articles to skip when retrieving. Note that this depends on the sort order specified by the `order` parameter.
-
-  - `length`: The number of articles to retrieve.
-
-  - `order[0][column]`: The column to sort the articles by. If not specified, defaults to article id. Values are as follows:
-      - 0 = article id
-      - 1 = date
-      - 2 = title
-      - 3 = authors
-      - 4 = rating
-  - `order[0][dir]`: The direction to sort, either `asc` or `desc`.
-
-  - `search[value]`: Specify a keyword for retrieving articles using full-text search.
-
-  - `extra`: This is a dictionary that contains facet-based filter parameters, which are described below. Parameters ending with `[]` can contain multiple values.
-      - `article_ids`: Filter based on ids.
-      - `mode`: Filter based on inclusion decision. Values can be `undecided`, `maybe`, `included`  `excluded` or `conflict` if the review blind mode is currently off.
-      - `searches[]`: Filter using search ids.
-      - `highlights_1[]`: Filter based on inclusion highlight keyword.
-      - `highlights_2[]`: Filter based on exclusion highlight keyword.
-      - `language[]`: Filter based on article language.
-      - `keyphrases[]`: Filter based on associated keywords, i.e. values from the “topics” facet.
-      - `locations[]`: Filters based on location of publication.
-      - `journal[]`: Filters based on journal of publication.
-      - `authors[]`: Filter based on listed authors.
-      - `year[]`: Filter based on year of publication.
-      - `publication_types[]` : Filter based on publication type.
-      - `user_labels[]`: Filter based on inserted user labels.
-      - `exclusion_labels[]`: Filter based on inserted exclusion labels.
-      - `abstract_languages[]`: Filter based on the abstract languages.
-      - `fulltext_types[]`: Filter based on uploaded full-text types. Values can be `pr` for private, `pu` for public.
-      - `customized_by[]`: Filter based on decisions made by users by specifiying user ids. If omitted, defaults to all users currently in the review.
-      - `decision_at_least`: Filter based on minimum collaborator decisions.
-      - `decision_at_most`: Filter based on maximum collaborator decisions.
-      - `dedup_result`: Filter based on dedup results. If not specified, retrieves all articles except those with the `deleted` dedup result. Values can be:
-          - 0 = unresolved
-          - 1 = deleted
-          - 2 = not duplicates
-          - 3 = resolved
-  				- all = retrieves all articles irrespective of dedup results.
-      - `dedup_job_id`: Filter based on dedup job id.
-      - `dedup_result_cluster_id`: Filter based on dedup result cluster id.
-      - `exact_matches[]`: Filter based on the number of exact matches hits.
-      - `pico_participants[]`: Filter based on PICO population keywords.
-      - `pico_intervention[]`: Filter based on PICO intervention keywords.
-      - `pico_control[]`: Filter based on PICO control keywords.
-      - `pico_outcome[]`: Filter based on PICO outcome keywords.
-
-  		
-  Furthermore, the export output can be customized to include abstracts, decisions, labels, notes, etc.
-
-  The customization options are as follows:
-
-
-  Set the following options to 1 to include them in the export or 0 to exclude them.
-
-  - `include_abstracts`
-
-  - `include_decisions`
-
-  - `include_labels`
-
-  - `include_exclusion_reasons`
-
-  - `include_user_notes`
-
-
-  - `author_format`: 
-  	-	`lf` for lastname then firstname
-  	- `fl` for firstname then lastname
+  Filters are passed in through the request body and are the same as the `GET /results` endpoint, with the exception of the `start`, `length`, `order[0][column]` and `order[0][dir]` attributes, which are not supported for copying reviews.
 method: POST
 body:
   mimeType: application/json

--- a/.insomnia/Request/req_b0483d6f0ea34b7eba74698e529ae1d1.yml
+++ b/.insomnia/Request/req_b0483d6f0ea34b7eba74698e529ae1d1.yml
@@ -1,0 +1,147 @@
+_id: req_b0483d6f0ea34b7eba74698e529ae1d1
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1676745409437
+created: 1676743495518
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/copy"
+name: Copy
+description: >-
+  Copy articles from one review to another based on specified filters. 
+
+
+  Indiciate the target review to copy by specifying it in the request body:
+
+
+  - `target_review`: (review id to copy to)
+
+
+  Filters are passed in through the request body and are described below:
+
+
+  - `start`: Number of initial articles to skip when retrieving. Note that this depends on the sort order specified by the `order` parameter.
+
+  - `length`: The number of articles to retrieve.
+
+  - `order[0][column]`: The column to sort the articles by. If not specified, defaults to article id. Values are as follows:
+      - 0 = article id
+      - 1 = date
+      - 2 = title
+      - 3 = authors
+      - 4 = rating
+  - `order[0][dir]`: The direction to sort, either `asc` or `desc`.
+
+  - `search[value]`: Specify a keyword for retrieving articles using full-text search.
+
+  - `extra`: This is a dictionary that contains facet-based filter parameters, which are described below. Parameters ending with `[]` can contain multiple values.
+      - `article_ids`: Filter based on ids.
+      - `mode`: Filter based on inclusion decision. Values can be `undecided`, `maybe`, `included`  `excluded` or `conflict` if the review blind mode is currently off.
+      - `searches[]`: Filter using search ids.
+      - `highlights_1[]`: Filter based on inclusion highlight keyword.
+      - `highlights_2[]`: Filter based on exclusion highlight keyword.
+      - `language[]`: Filter based on article language.
+      - `keyphrases[]`: Filter based on associated keywords, i.e. values from the “topics” facet.
+      - `locations[]`: Filters based on location of publication.
+      - `journal[]`: Filters based on journal of publication.
+      - `authors[]`: Filter based on listed authors.
+      - `year[]`: Filter based on year of publication.
+      - `publication_types[]` : Filter based on publication type.
+      - `user_labels[]`: Filter based on inserted user labels.
+      - `exclusion_labels[]`: Filter based on inserted exclusion labels.
+      - `abstract_languages[]`: Filter based on the abstract languages.
+      - `fulltext_types[]`: Filter based on uploaded full-text types. Values can be `pr` for private, `pu` for public.
+      - `customized_by[]`: Filter based on decisions made by users by specifiying user ids. If omitted, defaults to all users currently in the review.
+      - `decision_at_least`: Filter based on minimum collaborator decisions.
+      - `decision_at_most`: Filter based on maximum collaborator decisions.
+      - `dedup_result`: Filter based on dedup results. If not specified, retrieves all articles except those with the `deleted` dedup result. Values can be:
+          - 0 = unresolved
+          - 1 = deleted
+          - 2 = not duplicates
+          - 3 = resolved
+  				- all = retrieves all articles irrespective of dedup results.
+      - `dedup_job_id`: Filter based on dedup job id.
+      - `dedup_result_cluster_id`: Filter based on dedup result cluster id.
+      - `exact_matches[]`: Filter based on the number of exact matches hits.
+      - `pico_participants[]`: Filter based on PICO population keywords.
+      - `pico_intervention[]`: Filter based on PICO intervention keywords.
+      - `pico_control[]`: Filter based on PICO control keywords.
+      - `pico_outcome[]`: Filter based on PICO outcome keywords.
+
+  		
+  Furthermore, the export output can be customized to include abstracts, decisions, labels, notes, etc.
+
+  The customization options are as follows:
+
+
+  Set the following options to 1 to include them in the export or 0 to exclude them.
+
+  - `include_abstracts`
+
+  - `include_decisions`
+
+  - `include_labels`
+
+  - `include_exclusion_reasons`
+
+  - `include_user_notes`
+
+
+  - `author_format`: 
+  	-	`lf` for lastname then firstname
+  	- `fl` for firstname then lastname
+method: POST
+body:
+  mimeType: application/json
+  text: |-
+    {
+        "target_review": "{{ _.review_id2 }}",
+        "start": 0, 
+        "length": 5,
+        "order[0][column]": 1,
+        "order[0][dir]": "asc",
+        "search[value]": null,
+        "extra": {
+            "article_ids": [],
+            "mode": "undecided",
+            "searches": [],
+            "highlights_1": [],
+            "highlights_2": [],
+            "language": [],
+            "keyphrases": [],
+            "locations": [],
+            "journal": [],
+            "authors": [],
+            "year": [],
+            "publication_types": [],
+            "user_labels": [],
+            "exclusion_labels": [],
+            "abstract_languages": [],
+            "fulltext_types": [],
+            "customized_by": [],
+            "decision_at_least": [],
+            "decision_at_most": [],
+            "dedup_result": [],
+            "dedup_job_id": [],
+            "dedup_result_cluster_id": [],
+            "exact_matches": [],
+            "pico_participants": [],
+            "pico_intervention": [],
+            "pico_control": [],
+            "pico_outcome": []
+        }
+    }
+parameters: []
+headers:
+  - name: Content-Type
+    value: application/json
+    id: pair_f43b472486de45e096e256d9543d6942
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355063.375
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_f05681ed35694014b8febef40bab058e.yml
+++ b/.insomnia/Request/req_f05681ed35694014b8febef40bab058e.yml
@@ -1,0 +1,257 @@
+_id: req_f05681ed35694014b8febef40bab058e
+type: Request
+parentId: fld_eeb62a531f8441478a6d2f536021400d
+modified: 1676742946875
+created: 1676742404555
+url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/export"
+name: Export
+description: >-
+  Export articles from a review based on specified filters. Filters are passed
+  in as query parameters and are described below:
+
+
+  - `start`: Number of initial articles to skip when retrieving. Note that this depends on the sort order specified by the `order` parameter.
+
+  - `length`: The number of articles to retrieve.
+
+  - `order[0][column]`: The column to sort the articles by. If not specified, defaults to article id. Values are as follows:
+      - 0 = article id
+      - 1 = date
+      - 2 = title
+      - 3 = authors
+      - 4 = rating
+  - `order[0][dir]`: The direction to sort, either `asc` or `desc`.
+
+  - `search[value]`: Specify a keyword for retrieving articles using full-text search.
+
+  - `extra`: This is a dictionary that contains facet-based filter parameters, which are described below. Parameters ending with `[]` can contain multiple values.
+      - `article_ids`: Filter based on ids.
+      - `mode`: Filter based on inclusion decision. Values can be `undecided`, `maybe`, `included`  `excluded` or `conflict` if the review blind mode is currently off.
+      - `searches[]`: Filter using search ids.
+      - `highlights_1[]`: Filter based on inclusion highlight keyword.
+      - `highlights_2[]`: Filter based on exclusion highlight keyword.
+      - `language[]`: Filter based on article language.
+      - `keyphrases[]`: Filter based on associated keywords, i.e. values from the “topics” facet.
+      - `locations[]`: Filters based on location of publication.
+      - `journal[]`: Filters based on journal of publication.
+      - `authors[]`: Filter based on listed authors.
+      - `year[]`: Filter based on year of publication.
+      - `publication_types[]` : Filter based on publication type.
+      - `user_labels[]`: Filter based on inserted user labels.
+      - `exclusion_labels[]`: Filter based on inserted exclusion labels.
+      - `abstract_languages[]`: Filter based on the abstract languages.
+      - `fulltext_types[]`: Filter based on uploaded full-text types. Values can be `pr` for private, `pu` for public.
+      - `customized_by[]`: Filter based on decisions made by users by specifiying user ids. If omitted, defaults to all users currently in the review.
+      - `decision_at_least`: Filter based on minimum collaborator decisions.
+      - `decision_at_most`: Filter based on maximum collaborator decisions.
+      - `dedup_result`: Filter based on dedup results. If not specified, retrieves all articles except those with the `deleted` dedup result. Values can be:
+          - 0 = unresolved
+          - 1 = deleted
+          - 2 = not duplicates
+          - 3 = resolved
+  				- all = retrieves all articles irrespective of dedup results.
+      - `dedup_job_id`: Filter based on dedup job id.
+      - `dedup_result_cluster_id`: Filter based on dedup result cluster id.
+      - `exact_matches[]`: Filter based on the number of exact matches hits.
+      - `pico_participants[]`: Filter based on PICO population keywords.
+      - `pico_intervention[]`: Filter based on PICO intervention keywords.
+      - `pico_control[]`: Filter based on PICO control keywords.
+      - `pico_outcome[]`: Filter based on PICO outcome keywords.
+
+  		
+  Furthermore, the export output can be customized to include abstracts, decisions, labels, notes, etc.
+
+  The customization options are as follows:
+
+
+  Set the following options to 1 to include them in the export or 0 to exclude them.
+
+  - `include_abstracts`
+
+  - `include_decisions`
+
+  - `include_labels`
+
+  - `include_exclusion_reasons`
+
+  - `include_user_notes`
+
+
+  - `author_format`: 
+  	-	`lf` for lastname then firstname
+  	- `fl` for firstname then lastname
+method: GET
+body: {}
+parameters:
+  - id: pair_88a1385f2d05417b90214b2df7a0e2e9
+    name: start
+    value: "0"
+    description: ""
+    disabled: true
+  - id: pair_8743fd9dd80d448ab31d77f685c38371
+    name: length
+    value: "5"
+    description: ""
+    disabled: true
+  - id: pair_036b29f00fd742fca552074ee1c54704
+    name: order[0][column]
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_e1c89596528c4ddabfd84cdaeb9c575f
+    name: order[0][dir]
+    value: asc
+    description: ""
+    disabled: true
+  - id: pair_d5efdb03d8a7470fb897ec000da8e28d
+    name: search[value]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_3defd68e81ec42068e553d9082bf8047
+    name: extra[article_ids][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_8a8e4feb3c0544ff992f5016bd6bc2bb
+    name: extra[mode]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_1931bba60b0240f69104d0b1bb2c9084
+    name: extra[searches][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_39da1a4ed2d7462d932a83070389e657
+    name: extra[highlights_1][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_976c2e6034a04a79877d1d27e15d83cc
+    name: extra[highlights_2][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_d4fd6f6ac77647818953c2b2bba7bac1
+    name: extra[language][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_bbcb0e5179a2465ebceb7f4900386ffb
+    name: extra[keyphrases][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_91166c4bb67844b5ba9354d04baa5ed4
+    name: extra[locations][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_b7f68c09de0f433d96a47e843b803901
+    name: extra[journal][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_de9c0cee878c42f8a265392762753b72
+    name: extra[authors][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_4e94e8828f9547dc9e0f3761245b0c0c
+    name: extra[year][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_3dcca969b82748328ffc7576c2a731ce
+    name: extra[publication_types][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_47eaf3c973544b8cbc72bcbe6bbe3d72
+    name: extra[user_labels][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_ffa8dc9bbb7d4110a4f7a7757eff2e7f
+    name: extra[exclusion_labels][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_f100d06b60514ea1a58555faf4b8e135
+    name: extra[abstract_languages][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_c11b561430434300bc6031e344e1bd84
+    name: extra[fulltext_types][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_13cd849777aa4c1dbedfedcae1c68d74
+    name: extra[customized_by]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_2bb4e652538944e0b07f460d29468a12
+    name: extra[decision_at_least]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_ab4310ffd2fe4575b8355448159aa5a7
+    name: extra[decision_at_most]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_1cbb1ef87c2b40d5924c47801c77765b
+    name: extra[dedup_result]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_b237f7b62b1d400b947fab3bf1eb8d0e
+    name: extra[dedup_job_id]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_06433e7cc300485aa3d50e63e14047f9
+    name: extra[dedup_result_cluster_id]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_9e8ea344dfa145d187b565bfd28ab1b7
+    name: extra[exact_matches]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_06def708297a44db99609b6e07b90c8a
+    name: extra[pico_participants][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_f38269bac51949bb99b351ed4355ca87
+    name: extra[pico_intervention][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_07e4eef78c554bbf87f10b9d5589c7f3
+    name: extra[pico_control][]
+    value: ""
+    description: ""
+    disabled: true
+  - id: pair_91a0c5df1566470bb7a147dab5884550
+    name: extra[pico_outcome][]
+    value: ""
+    description: ""
+    disabled: true
+headers: []
+authentication:
+  type: bearer
+  token: "{{ _.manual_token }}"
+metaSortKey: -1643841355064.25
+isPrivate: false
+settingStoreCookies: true
+settingSendCookies: true
+settingDisableRenderRequestBody: false
+settingEncodeUrl: true
+settingRebuildPath: true
+settingFollowRedirects: global

--- a/.insomnia/Request/req_f05681ed35694014b8febef40bab058e.yml
+++ b/.insomnia/Request/req_f05681ed35694014b8febef40bab058e.yml
@@ -1,7 +1,7 @@
 _id: req_f05681ed35694014b8febef40bab058e
 type: Request
 parentId: fld_eeb62a531f8441478a6d2f536021400d
-modified: 1676742946875
+modified: 1677773623282
 created: 1676742404555
 url: "{{ _.base_url }}/api/v1/reviews/{{ _.review_id }}/export"
 name: Export
@@ -10,54 +10,7 @@ description: >-
   in as query parameters and are described below:
 
 
-  - `start`: Number of initial articles to skip when retrieving. Note that this depends on the sort order specified by the `order` parameter.
-
-  - `length`: The number of articles to retrieve.
-
-  - `order[0][column]`: The column to sort the articles by. If not specified, defaults to article id. Values are as follows:
-      - 0 = article id
-      - 1 = date
-      - 2 = title
-      - 3 = authors
-      - 4 = rating
-  - `order[0][dir]`: The direction to sort, either `asc` or `desc`.
-
-  - `search[value]`: Specify a keyword for retrieving articles using full-text search.
-
-  - `extra`: This is a dictionary that contains facet-based filter parameters, which are described below. Parameters ending with `[]` can contain multiple values.
-      - `article_ids`: Filter based on ids.
-      - `mode`: Filter based on inclusion decision. Values can be `undecided`, `maybe`, `included`  `excluded` or `conflict` if the review blind mode is currently off.
-      - `searches[]`: Filter using search ids.
-      - `highlights_1[]`: Filter based on inclusion highlight keyword.
-      - `highlights_2[]`: Filter based on exclusion highlight keyword.
-      - `language[]`: Filter based on article language.
-      - `keyphrases[]`: Filter based on associated keywords, i.e. values from the “topics” facet.
-      - `locations[]`: Filters based on location of publication.
-      - `journal[]`: Filters based on journal of publication.
-      - `authors[]`: Filter based on listed authors.
-      - `year[]`: Filter based on year of publication.
-      - `publication_types[]` : Filter based on publication type.
-      - `user_labels[]`: Filter based on inserted user labels.
-      - `exclusion_labels[]`: Filter based on inserted exclusion labels.
-      - `abstract_languages[]`: Filter based on the abstract languages.
-      - `fulltext_types[]`: Filter based on uploaded full-text types. Values can be `pr` for private, `pu` for public.
-      - `customized_by[]`: Filter based on decisions made by users by specifiying user ids. If omitted, defaults to all users currently in the review.
-      - `decision_at_least`: Filter based on minimum collaborator decisions.
-      - `decision_at_most`: Filter based on maximum collaborator decisions.
-      - `dedup_result`: Filter based on dedup results. If not specified, retrieves all articles except those with the `deleted` dedup result. Values can be:
-          - 0 = unresolved
-          - 1 = deleted
-          - 2 = not duplicates
-          - 3 = resolved
-  				- all = retrieves all articles irrespective of dedup results.
-      - `dedup_job_id`: Filter based on dedup job id.
-      - `dedup_result_cluster_id`: Filter based on dedup result cluster id.
-      - `exact_matches[]`: Filter based on the number of exact matches hits.
-      - `pico_participants[]`: Filter based on PICO population keywords.
-      - `pico_intervention[]`: Filter based on PICO intervention keywords.
-      - `pico_control[]`: Filter based on PICO control keywords.
-      - `pico_outcome[]`: Filter based on PICO outcome keywords.
-
+  Filters are passed in through the request body and are the same as the `GET /results` endpoint, with the exception of the `start`, `length`, `order[0][column]` and `order[0][dir]` attributes, which are not supported for exporting reviews.
   		
   Furthermore, the export output can be customized to include abstracts, decisions, labels, notes, etc.
 
@@ -241,6 +194,36 @@ parameters:
   - id: pair_91a0c5df1566470bb7a147dab5884550
     name: extra[pico_outcome][]
     value: ""
+    description: ""
+    disabled: true
+  - id: pair_09ee6c98425c4537a007066325d71892
+    name: include_abstracts
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_79e73d7ff68e4f748ef56e9c0293fef4
+    name: include_decisions
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_0ae926e627a04751a7a4c507eb34d113
+    name: include_labels
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_49530fbcfbfd483a8953f22a7ce59ee4
+    name: include_exclusion_reasons
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_98f41592be8e4ab580eff452ebae4d90
+    name: include_user_notes
+    value: "1"
+    description: ""
+    disabled: true
+  - id: pair_1026a040038a4742b1bb6198a11b91a1
+    name: author_format
+    value: "1"
     description: ""
     disabled: true
 headers: []


### PR DESCRIPTION
This PR adds documentation for the following endpoints:

* GET `/api/v1/reviews/:review_id/duplicates/:article_id`
* POST `/api/v1/reviews/:review_id/duplicates`
* PATCH `/api/v1/reviews/:review_id/duplicates/article_id`
* POST `/api/v1/reviews/:review_id/copy`
* GET `/api/v1/reviews/:review_id/export`